### PR TITLE
reset earnings counter during time passing screen each time

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -125,6 +125,7 @@ function continueStory() {
     // Animate meter readouts
     if (earnings !== earningsObj.totalValue) {
       console.log('Earnings changed, animating meter readout');
+      earningsObj.value = earningsObj.totalValue;
 
       anime({
         targets: earningsObj,
@@ -144,7 +145,6 @@ function continueStory() {
         },
         complete: () => {
           earningsDisplay.style.textShadow = 'none';
-          earningsObj.value = earnings;
           earningsObj.totalValue = earnings;
         },
       });
@@ -474,7 +474,7 @@ function startStory() {
       easing: 'linear',
       offset: 0,
       begin: () => {
-        earningsDisplay.innerHTML = earningsObj.value;
+        earningsDisplay.innerHTML = earningsObj.totalValue;
         timeDisplay.innerHTML = `${timeString.slice(0, 4)}${timeString.slice(-2)}`;
         ratingDisplay.innerHTML = (ratingObj.value / 100).toFixed(2);
         knotContainer.style.transform = 'translateY(40px)';


### PR DESCRIPTION
Changes earnings counter code on time passing screens so that it only displays earnings during that period, not total earnings from the game.

@RobinKwong, can you please check this?